### PR TITLE
refactor(type): move context definitions into separate modules

### DIFF
--- a/crates/type/src/repository/context.rs
+++ b/crates/type/src/repository/context.rs
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: 2022 Profian Inc. <opensource@profian.com>
+// SPDX-License-Identifier: AGPL-3.0-only
+
+use super::super::UserContext;
+use super::Name;
+
+use std::fmt::Display;
+use std::str::FromStr;
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct Context {
+    pub owner: UserContext,
+    pub name: Name,
+}
+
+impl FromStr for Context {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (owner, name) = s.split_once('/').ok_or("invalid repository context")?;
+        let owner = owner.parse()?;
+        let name = name.parse()?;
+        Ok(Self { owner, name })
+    }
+}
+
+impl Display for Context {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}/{}", self.owner, self.name)
+    }
+}
+
+#[cfg(feature = "axum")]
+#[axum::async_trait]
+impl<B: Send> axum::extract::FromRequest<B> for Context {
+    type Rejection = axum::http::StatusCode;
+
+    async fn from_request(
+        req: &mut axum::extract::RequestParts<B>,
+    ) -> Result<Self, Self::Rejection> {
+        let owner = req.extract().await?;
+        let axum::Extension(name) = req.extract().await.map_err(|e| {
+            eprintln!(
+                "{}",
+                anyhow::Error::new(e).context("failed to extract repository name")
+            );
+            axum::http::StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+        Ok(Self { owner, name })
+    }
+}

--- a/crates/type/src/repository/mod.rs
+++ b/crates/type/src/repository/mod.rs
@@ -2,55 +2,9 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 mod config;
+mod context;
 mod name;
 
 pub use config::*;
+pub use context::*;
 pub use name::*;
-
-use super::user;
-
-use std::fmt::Display;
-use std::str::FromStr;
-
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct Context {
-    pub owner: user::Context,
-    pub name: Name,
-}
-
-impl FromStr for Context {
-    type Err = &'static str;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let (owner, name) = s.split_once('/').ok_or("invalid repository context")?;
-        let owner = owner.parse()?;
-        let name = name.parse()?;
-        Ok(Self { owner, name })
-    }
-}
-
-impl Display for Context {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}/{}", self.owner, self.name)
-    }
-}
-
-#[cfg(feature = "axum")]
-#[axum::async_trait]
-impl<B: Send> axum::extract::FromRequest<B> for Context {
-    type Rejection = axum::http::StatusCode;
-
-    async fn from_request(
-        req: &mut axum::extract::RequestParts<B>,
-    ) -> Result<Self, Self::Rejection> {
-        let owner = req.extract().await?;
-        let axum::Extension(name) = req.extract().await.map_err(|e| {
-            eprintln!(
-                "{}",
-                anyhow::Error::new(e).context("failed to extract repository name")
-            );
-            axum::http::StatusCode::INTERNAL_SERVER_ERROR
-        })?;
-        Ok(Self { owner, name })
-    }
-}

--- a/crates/type/src/tag/context.rs
+++ b/crates/type/src/tag/context.rs
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: 2022 Profian Inc. <opensource@profian.com>
+// SPDX-License-Identifier: AGPL-3.0-only
+
+use super::super::RepositoryContext;
+use super::Name;
+
+use std::fmt::Display;
+// TODO: Uncomment once compiler bug is fixed
+//use std::str::FromStr;
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct Context {
+    pub repository: RepositoryContext,
+    pub name: Name,
+}
+
+// TODO: Uncomment once compiler bug is fixed
+//impl FromStr for Context {
+//    type Err = &'static str;
+//
+//    fn from_str(s: &str) -> Result<Self, Self::Err> {
+//        let (repository, name) = s.split_once(":").ok_or("invalid tag context")?;
+//        let repository = repository.parse()?;
+//        let name = name.parse().map_err(Into::into)?;
+//        Ok(Self { repository, name })
+//    }
+//}
+
+impl Display for Context {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}:{}", self.repository, self.name)
+    }
+}
+
+#[cfg(feature = "axum")]
+#[axum::async_trait]
+impl<B: Send> axum::extract::FromRequest<B> for Context {
+    type Rejection = axum::http::StatusCode;
+
+    async fn from_request(
+        req: &mut axum::extract::RequestParts<B>,
+    ) -> Result<Self, Self::Rejection> {
+        let repository = req.extract().await?;
+        let axum::Extension(name) = req.extract().await.map_err(|e| {
+            eprintln!(
+                "{}",
+                anyhow::Error::new(e).context("failed to extract tag name")
+            );
+            axum::http::StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+        Ok(Self { repository, name })
+    }
+}

--- a/crates/type/src/tag/mod.rs
+++ b/crates/type/src/tag/mod.rs
@@ -1,58 +1,10 @@
 // SPDX-FileCopyrightText: 2022 Profian Inc. <opensource@profian.com>
 // SPDX-License-Identifier: AGPL-3.0-only
 
+mod context;
 mod entry;
 mod name;
 
+pub use context::*;
 pub use entry::*;
 pub use name::*;
-
-use super::repository;
-
-use std::fmt::Display;
-// TODO: Uncomment once compiler bug is fixed
-//use std::str::FromStr;
-
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct Context {
-    pub repository: repository::Context,
-    pub name: Name,
-}
-
-// TODO: Uncomment once compiler bug is fixed
-//impl FromStr for Context {
-//    type Err = &'static str;
-//
-//    fn from_str(s: &str) -> Result<Self, Self::Err> {
-//        let (repository, name) = s.split_once(":").ok_or("invalid tag context")?;
-//        let repository = repository.parse()?;
-//        let name = name.parse().map_err(Into::into)?;
-//        Ok(Self { repository, name })
-//    }
-//}
-
-impl Display for Context {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}:{}", self.repository, self.name)
-    }
-}
-
-#[cfg(feature = "axum")]
-#[axum::async_trait]
-impl<B: Send> axum::extract::FromRequest<B> for Context {
-    type Rejection = axum::http::StatusCode;
-
-    async fn from_request(
-        req: &mut axum::extract::RequestParts<B>,
-    ) -> Result<Self, Self::Rejection> {
-        let repository = req.extract().await?;
-        let axum::Extension(name) = req.extract().await.map_err(|e| {
-            eprintln!(
-                "{}",
-                anyhow::Error::new(e).context("failed to extract tag name")
-            );
-            axum::http::StatusCode::INTERNAL_SERVER_ERROR
-        })?;
-        Ok(Self { repository, name })
-    }
-}

--- a/crates/type/src/tree/context.rs
+++ b/crates/type/src/tree/context.rs
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2022 Profian Inc. <opensource@profian.com>
+// SPDX-License-Identifier: AGPL-3.0-only
+
+use super::super::TagContext;
+use super::Path;
+
+use std::fmt::Display;
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct Context {
+    pub tag: TagContext,
+    pub path: Path,
+}
+
+impl Display for Context {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}/{}", self.tag, self.path)
+    }
+}
+
+#[cfg(feature = "axum")]
+#[axum::async_trait]
+impl<B: Send> axum::extract::FromRequest<B> for Context {
+    type Rejection = axum::http::StatusCode;
+
+    async fn from_request(
+        req: &mut axum::extract::RequestParts<B>,
+    ) -> Result<Self, Self::Rejection> {
+        let tag = req.extract().await?;
+        let axum::Extension(path) = req.extract().await.map_err(|e| {
+            eprintln!(
+                "{}",
+                anyhow::Error::new(e).context("failed to extract tree path")
+            );
+            axum::http::StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+        Ok(Self { tag, path })
+    }
+}

--- a/crates/type/src/tree/mod.rs
+++ b/crates/type/src/tree/mod.rs
@@ -1,46 +1,12 @@
 // SPDX-FileCopyrightText: 2022 Profian Inc. <opensource@profian.com>
 // SPDX-License-Identifier: AGPL-3.0-only
 
+mod context;
 mod directory;
 mod entry;
 mod path;
 
+pub use context::*;
 pub use directory::*;
 pub use entry::*;
 pub use path::*;
-
-use super::tag;
-
-use std::fmt::Display;
-
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct Context {
-    pub tag: tag::Context,
-    pub path: Path,
-}
-
-impl Display for Context {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}/{}", self.tag, self.path)
-    }
-}
-
-#[cfg(feature = "axum")]
-#[axum::async_trait]
-impl<B: Send> axum::extract::FromRequest<B> for Context {
-    type Rejection = axum::http::StatusCode;
-
-    async fn from_request(
-        req: &mut axum::extract::RequestParts<B>,
-    ) -> Result<Self, Self::Rejection> {
-        let tag = req.extract().await?;
-        let axum::Extension(path) = req.extract().await.map_err(|e| {
-            eprintln!(
-                "{}",
-                anyhow::Error::new(e).context("failed to extract tree path")
-            );
-            axum::http::StatusCode::INTERNAL_SERVER_ERROR
-        })?;
-        Ok(Self { tag, path })
-    }
-}

--- a/crates/type/src/user/context.rs
+++ b/crates/type/src/user/context.rs
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: 2022 Profian Inc. <opensource@profian.com>
+// SPDX-License-Identifier: AGPL-3.0-only
+
+use super::Name;
+
+use std::fmt::Display;
+use std::str::FromStr;
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct Context {
+    pub name: Name,
+}
+
+impl FromStr for Context {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let name = s.parse()?;
+        Ok(Self { name })
+    }
+}
+
+impl Display for Context {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.name)
+    }
+}
+
+#[cfg(feature = "axum")]
+#[axum::async_trait]
+impl<B: Send> axum::extract::FromRequest<B> for Context {
+    type Rejection = axum::http::StatusCode;
+
+    async fn from_request(
+        req: &mut axum::extract::RequestParts<B>,
+    ) -> Result<Self, Self::Rejection> {
+        let axum::Extension(name) = req.extract().await.map_err(|e| {
+            eprintln!(
+                "{}",
+                anyhow::Error::new(e).context("failed to extract user name")
+            );
+            axum::http::StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+        Ok(Self { name })
+    }
+}

--- a/crates/type/src/user/mod.rs
+++ b/crates/type/src/user/mod.rs
@@ -2,49 +2,9 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 mod config;
+mod context;
 mod name;
 
 pub use config::*;
+pub use context::*;
 pub use name::*;
-
-use std::fmt::Display;
-use std::str::FromStr;
-
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct Context {
-    pub name: Name,
-}
-
-impl FromStr for Context {
-    type Err = &'static str;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let name = s.parse()?;
-        Ok(Self { name })
-    }
-}
-
-impl Display for Context {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.name)
-    }
-}
-
-#[cfg(feature = "axum")]
-#[axum::async_trait]
-impl<B: Send> axum::extract::FromRequest<B> for Context {
-    type Rejection = axum::http::StatusCode;
-
-    async fn from_request(
-        req: &mut axum::extract::RequestParts<B>,
-    ) -> Result<Self, Self::Rejection> {
-        let axum::Extension(name) = req.extract().await.map_err(|e| {
-            eprintln!(
-                "{}",
-                anyhow::Error::new(e).context("failed to extract user name")
-            );
-            axum::http::StatusCode::INTERNAL_SERVER_ERROR
-        })?;
-        Ok(Self { name })
-    }
-}


### PR DESCRIPTION
~A few things I noticed and fixed while working on another PR, do not really fit into a single category.~
~Opening just one PR to avoid having to rebase after merges. These could also be 3 different PRs if you prefer.~ 

Move context definitions into separate modules for better code organization. We are likely to add more functionality to `mod.rs` (as is already done in an upcoming PR)